### PR TITLE
Drop version constraints from rake, bundler

### DIFF
--- a/benchmark_driver-output-charty.gemspec
+++ b/benchmark_driver-output-charty.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "benchmark_driver"
   spec.add_dependency "charty"
   spec.add_dependency "matplotlib"
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
* Prohibiting Bundler 2 is problematic for using Ruby 2.7
* I also want to use the latest rake to remove warnings on Ruby 2.7