### PR TITLE
Support box_plot for single job benchmark

### DIFF
--- a/benchmark_driver-output-charty.gemspec
+++ b/benchmark_driver-output-charty.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "benchmark_driver"
+  spec.add_dependency "benchmark_driver", ">= 0.15.0"
   spec.add_dependency "charty"
   spec.add_dependency "matplotlib"
   spec.add_development_dependency "bundler", "~> 1.17"

--- a/benchmark_driver-output-charty.gemspec
+++ b/benchmark_driver-output-charty.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "benchmark_driver", ">= 0.15.0"
+  spec.add_dependency "benchmark_driver", ">= 0.15.1"
   spec.add_dependency "charty"
   spec.add_dependency "matplotlib"
   spec.add_development_dependency "bundler", "~> 1.17"

--- a/lib/benchmark_driver/output/charty.rb
+++ b/lib/benchmark_driver/output/charty.rb
@@ -4,12 +4,17 @@ require 'benchmark_driver'
 class BenchmarkDriver::Output::Charty < BenchmarkDriver::BulkOutput
   GRAPH_PATH = 'charty.png'
 
+  OPTIONS = {
+    path: ['--output-path PATH', String, "Chart output path (default: #{GRAPH_PATH})"]
+  }
+
   # @param [Array<BenchmarkDriver::Metric>] metrics
   # @param [Array<BenchmarkDriver::Job>] jobs
   # @param [Array<BenchmarkDriver::Context>] contexts
-  def initialize(contexts:, **)
+  def initialize(contexts:, options:, **)
     super
     @contexts = contexts
+    @path = options.fetch(:path, GRAPH_PATH)
   end
 
   # @param [Hash{ BenchmarkDriver::Job => Hash{ BenchmarkDriver::Context => { BenchmarkDriver::Metric => Float } } }] result
@@ -28,7 +33,7 @@ class BenchmarkDriver::Output::Charty < BenchmarkDriver::BulkOutput
         series names, values
         ylabel metric.unit
       end
-      barh.save("charty.png")
+      barh.save(@path)
     else
       jobs = job_context_result.keys
       values = @contexts.map{|context|
@@ -44,9 +49,9 @@ class BenchmarkDriver::Output::Charty < BenchmarkDriver::BulkOutput
         end
         ylabel metric.unit
       end
-      barh.save("charty.png")
+      barh.save(@path)
     end
-    puts ": #{GRAPH_PATH}"
+    puts ": #{@path}"
   end
 
   def with_job(job, &block)

--- a/lib/benchmark_driver/output/charty.rb
+++ b/lib/benchmark_driver/output/charty.rb
@@ -5,6 +5,7 @@ class BenchmarkDriver::Output::Charty < BenchmarkDriver::BulkOutput
   GRAPH_PATH = 'charty.png'
 
   OPTIONS = {
+    chart: ['--output-chart CHART', Regexp.union(['bar', 'box']), 'Specify chart type: bar, box (default: bar)'],
     path: ['--output-path PATH', String, "Chart output path (default: #{GRAPH_PATH})"]
   }
 
@@ -14,6 +15,7 @@ class BenchmarkDriver::Output::Charty < BenchmarkDriver::BulkOutput
   def initialize(contexts:, options:, **)
     super
     @contexts = contexts
+    @chart = options.fetch(:chart, 'bar')
     @path = options.fetch(:path, GRAPH_PATH)
   end
 
@@ -28,29 +30,47 @@ class BenchmarkDriver::Output::Charty < BenchmarkDriver::BulkOutput
       job = job_context_result.keys.first
 
       names = job_context_result[job].keys.map(&:name)
-      values = job_context_result[job].values.map { |result| result.values.fetch(metric) }
-      barh = charty.barh do
-        series names, values
-        ylabel metric.unit
+      case @chart
+      when 'bar'
+        values = job_context_result[job].values.map { |result| result.values.fetch(metric) }
+        chart = charty.barh do
+          series names, values
+          ylabel metric.unit
+        end
+      when 'box'
+        values = job_context_result[job].values.map { |result| result.all_values.fetch(metric) }
+        chart = charty.box_plot do
+          labels names
+          data values
+          ylabel metric.unit
+        end
+      else
+        raise ArgumentError, "unexpected --output-chart: #{@chart}"
       end
-      barh.save(@path)
     else
       jobs = job_context_result.keys
-      values = @contexts.map{|context|
-        [
-          jobs.map{|job| "#{job.name}(#{context.name})" },
-          jobs.map{|job| job_context_result[job][context].values.fetch(metric).round }
-        ]
-      }
 
-      barh = charty.barh do
-        values.each do |value|
-          series *value
+      case @chart
+      when 'bar'
+        values = @contexts.map{|context|
+          [
+            jobs.map{|job| "#{job.name}(#{context.name})" },
+            jobs.map{|job| job_context_result[job][context].values.fetch(metric).round }
+          ]
+        }
+        chart = charty.barh do
+          values.each do |value|
+            series *value
+          end
+          ylabel metric.unit
         end
-        ylabel metric.unit
+      when 'box'
+        raise NotImplementedError, "--output-chart=box is not supported with multiple jobs"
+      else
+        raise ArgumentError, "unexpected --output-chart: #{@chart}"
       end
-      barh.save(@path)
     end
+    chart.save(@path)
     puts ": #{@path}"
   end
 


### PR DESCRIPTION
This PR makes it possible to use `box_plot` by:

```bash
benchmark-driver --output=charty --output-chart=box \
  --rbenv '2.5.6;2.6.4' --repeat-count=4 benchmark.yml
```

![charty](https://user-images.githubusercontent.com/3138447/64439382-c8c5ee80-d104-11e9-8d83-24852ee36efd.png)
