### PR TITLE
Migrate to the new API of Charty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,15 @@
 source "https://rubygems.org"
 
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 # Specify your gem's dependencies in benchmark_driver-output-charty.gemspec
 gemspec
+
+# To experiment unicode_plot which is not released yet + fix #52
+gem 'charty', github: 'k0kubun/charty', ref: 'bar-labels'
+
+# https://github.com/red-data-tools/charty/issues/51
+gem 'numo-narray'

--- a/benchmark_driver-output-charty.gemspec
+++ b/benchmark_driver-output-charty.gemspec
@@ -25,9 +25,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "benchmark_driver", ">= 0.15.1"
-  spec.add_dependency "charty"
+  spec.add_dependency "charty", ">= 0.2.0"
   spec.add_dependency "matplotlib"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
+  spec.add_development_dependency "unicode_plot"
 end

--- a/lib/benchmark_driver/output/charty.rb
+++ b/lib/benchmark_driver/output/charty.rb
@@ -6,7 +6,7 @@ class BenchmarkDriver::Output::Charty < BenchmarkDriver::BulkOutput
   DEFAULT_CHART = 'bar'
 
   OPTIONS = {
-    backend: ['--output-backend BACKEND', Regexp.union(Charty::Backends.names), "Chart backend (default: #{DEFAULT_BACKEND})"],
+    backend: ['--output-backend BACKEND', Regexp.union(Charty::Backends.names), "Chart backend: #{Charty::Backends.names.join(', ')} (default: #{DEFAULT_BACKEND})"],
     chart: ['--output-chart CHART', Regexp.union(['bar', 'box']), "Specify chart type: bar, box (default: #{DEFAULT_CHART})"],
   }
 


### PR DESCRIPTION
## Description
Because the new API doesn't seem to have `save` support, I tentatively removed `--output-path` option for the migration.

I wanted to do this migration because the new unicode_plot integration seems to work only on the new API.

## Example
### bar
```
$ benchmark-driver --rbenv '2.6.3;2.7.0' -o charty --output-chart=bar --output-backend=unicode_plot ../../ruby/ruby/benchmark/cgi_escape_html.yml --filter long
escape_html_long_none: 2.6.3, 2.7.0
escape_html_long_all: 2.6.3, 2.7.0

escape_html_long_none
         ┌                                        ┐
   2.6.3 ┤■■■■■■■■■■■■■■■■■■■■ 1359514.2792638692
   2.7.0 ┤■■■■■■■■■■■■■■■■■■ 1190561.6359507383
         └                                        ┘

escape_html_long_all
         ┌                                        ┐
   2.6.3 ┤■■■■ 1104196.337961903
   2.7.0 ┤■■■■■■■■■■■■■■■■■■■■■ 5301044.206587828
         └                                        ┘
```

### box
```
$ benchmark-driver --rbenv '2.7.0;2.7.0 --jit' -o charty --output-chart=box --output-backend=unicode_plot ../../mame/optcarrot/benchmark.yml --repeat-count=8
Optcarrot Lan_Master.nes: 2.7.0, 2.7.0 --jit
               ┌                                        ┐
                 ╷╷
         2.7.0   ├┤
                 ╵╵
                                     ╷    ┌───┬┐╷
   2.7.0 --jit                       ├────┤   │├┤
                                     ╵    └───┴┘╵
               └                                        ┘
               50                 70                   90
```